### PR TITLE
Avoid location.reload, properly decode hash

### DIFF
--- a/inst/htmlwidgets/lib/d3cartogram.js
+++ b/inst/htmlwidgets/lib/d3cartogram.js
@@ -404,7 +404,7 @@ datasettransition, datasettransitioneasingfunction, mapzoomswitch, mapprojection
             .attr("disabled", null);
 
           deferredUpdate();
-          location.replace("#" + [field.id, year].join("/"));
+          location.hash = "#" + [field.id, year].join("/");
           //location.replace("#" + field.id);
 
           hashish.attr("href", function(href) {

--- a/inst/htmlwidgets/lib/d3cartogram.js
+++ b/inst/htmlwidgets/lib/d3cartogram.js
@@ -368,7 +368,8 @@ datasettransition, datasettransitioneasingfunction, mapzoomswitch, mapprojection
         });
 
       function parseHash() {
-        var parts = location.hash.substr(1).split("/"),
+        var parsedHash = decodeURIComponent(location.hash);
+        var parts = parsedHash.substr(1).split("/"),
             desiredFieldId = parts[0],
             desiredYear = +parts[1];
 


### PR DESCRIPTION
The first commit here makes the reading side of the location.hash respect the `encodeURIComponent` added in 06d74d36abed3f5e20dc276dc6efe7a253f17478. (In retrospect, I think you could revert both that commit and 2206219. But if you have one, you should have both.)

The final commit fixes the infinite redirect issue. The foundational issue is that we use a `<base href>` and using `location.replace` with just a hash would redirect the browser to the `<base href>` page plus the new hash, rather than staying on the current page and just adding a hash. We now just modify the hash to avoid reloading the page with a new URL.